### PR TITLE
Using function pow instead of ^ operator

### DIFF
--- a/pyext/src/sampling.py
+++ b/pyext/src/sampling.py
@@ -573,7 +573,7 @@ def enumerate_fragment(frag, exp_grid, sig, num_models = 1):
     possible_number_combinations = list(combinations_with_replacement(range(n), nbin))
     #all_possible_combinations = list(product(range(n), repeat=nbin))
     score = 0
-    minscore = 1.0*10^34
+    minscore = 1.0*pow(10,34)
     for i in possible_number_combinations:
         if sum(i) == n:
             numbers = list(i)


### PR DESCRIPTION
the ^ operator does not work in python 3.6

> Fragment start_res end_res exp_grid
Traceback (most recent call last):
  File "/usr/local/bayesian_hdx/examples/workbench_executable.py", line 128, in <module>
    init = init)
  File "/usr/local/bayesian_hdx/pyext/src/hdx_models.py", line 81, in __init__
    self.guess_init_exp_sequence(5)
  File "/usr/local/bayesian_hdx/pyext/src/hdx_models.py", line 203, in guess_init_exp_sequence
    f.exp_vals = sampling.enumerate_fragment(f, exp_grid, 2.0, num_models = 1)
  File "/usr/local/bayesian_hdx/pyext/src/sampling.py", line 576, in enumerate_fragment
    minscore = 1.0*10^34
TypeError: unsupported operand type(s) for ^: 'float' and 'int'